### PR TITLE
fix: fill empty prettierrc with default config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,18 @@
+{
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "htmlWhitespaceSensitivity": "css",
+  "insertPragma": false,
+  "jsxBracketSameLine": false,
+  "jsxSingleQuote": false,
+  "printWidth": 80,
+  "proseWrap": "preserve",
+  "quoteProps": "as-needed",
+  "requirePragma": false,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false,
+  "vueIndentScriptAndStyle": false
+}


### PR DESCRIPTION
I accidentally committed an empty `.prettierrc` file.
The configuration added by this PR is not different from the default configuration, that has been used for the initial formatting.

Why use a config at all, if it isn't different from the default/fallback configuration?

In the past, some defaults have been changed. Even though this was always mentioned in the changelog of prettier and only happened for major versions, its still possible to miss it and be surprised. Using a configuration file locks down as much as possible in an explicit way.