### PR TITLE
feat: add logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "passport-github2": "^0.1.12",
     "pathfinding": "^0.4.18",
     "paths-js": "^0.4.10",
+    "pino": "^6.5.1",
     "react": "^16.13.1",
     "react-bootstrap": "^1.0.0",
     "react-dom": "^16.13.1",
@@ -57,16 +58,16 @@
     "deploy": "gh-pages -d build",
     "format": "prettier --write \"src/**/*.{js,jsx, ts, tsx}\""
   },
-    "husky": {
+  "husky": {
     "hooks": {
       "pre-commit": "lint-staged"
     }
   },
- "lint-staged": {
-   "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
-     "prettier --write"
-   ]
- },
+  "lint-staged": {
+    "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
+      "prettier --write"
+    ]
+  },
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/src/components/FlowChart/Sidebar.jsx
+++ b/src/components/FlowChart/Sidebar.jsx
@@ -4,6 +4,7 @@ import defaultPods from "../../data/defaultPods.json";
 import lunr from "lunr";
 import { Button, FormControl, Card } from "react-bootstrap";
 import { Store } from "../../flux";
+import { logger } from "../../logger";
 
 class FlowChartSidebar extends React.Component {
   state = {
@@ -20,7 +21,7 @@ class FlowChartSidebar extends React.Component {
     if (id === this.state.node.id) return;
 
     this.setState({ searchResults: [], searchQuery: "" });
-    console.log("test");
+    logger.info("test");
 
     if (!id) return;
 
@@ -31,7 +32,7 @@ class FlowChartSidebar extends React.Component {
   };
 
   setInitialNode = (node) => {
-    console.log("setInititailNode:", node);
+    logger.info("setInititailNode:", node);
     const properties = {};
     const newProperties = {};
     const label = node.label;
@@ -70,7 +71,7 @@ class FlowChartSidebar extends React.Component {
   saveChanges = () => {
     const { node } = this.state;
     this.props.updateNode(node);
-    console.log("save changes: ", node);
+    logger.info("save changes: ", node);
   };
 
   updateSearchQuery = (e) => {
@@ -79,18 +80,18 @@ class FlowChartSidebar extends React.Component {
 
   searchProperties = () => {
     const query = this.state.searchQuery;
-    console.log("search query: ", query);
+    logger.info("search query: ", query);
     if (!query) return this.setState({ searchResults: false });
     this.indexProperties();
     let searchResults = this.index.search(`${query} ${query}*`);
     this.setState({ searchResults });
-    console.log("search results: ", searchResults);
+    logger.info("search results: ", searchResults);
   };
 
   indexProperties = () => {
     const { availableProperties, node } = this.state;
     const { properties } = node;
-    console.log(
+    logger.info(
       "indexing",
       availableProperties.length,
       "properties for search"
@@ -237,7 +238,7 @@ class FlowChartSidebar extends React.Component {
       return { label: nodes[id].label || nodes[id].properties.name, id };
     });
 
-    console.log("links:", links, "\nlink:", link, "\nnodes:", nodes);
+    logger.info("links:", links, "\nlink:", link, "\nnodes:", nodes);
     return (
       <div className="h-100 d-flex flex-column">
         <h5 className="px-3 py-2 mb-0 border-bottom">

--- a/src/components/LogStream/LogStream.jsx
+++ b/src/components/LogStream/LogStream.jsx
@@ -13,6 +13,7 @@ import LogItem from "./LogItem";
 import lunr from "lunr";
 import { saveAs } from "file-saver";
 import { Store } from "../../flux";
+import { logger } from "../../logger";
 
 import List from "react-virtualized/dist/commonjs/List";
 import AutoSizer from "react-virtualized/dist/commonjs/AutoSizer";
@@ -106,7 +107,7 @@ class StreamContainer extends React.Component {
     const selectedLevel = false;
     const logs = this.state.allLogs;
     this.setState({ selectedSource, selectedLevel, logs });
-    console.log("scrolling to index: ", index);
+    logger.info("scrolling to index: ", index);
     this.scrollToLog(index);
   };
 
@@ -137,12 +138,12 @@ class StreamContainer extends React.Component {
 
   search = () => {
     const query = this.state.searchQuery;
-    console.log("search query: ", query);
+    logger.info("search query: ", query);
     if (!query) return this.setState({ results: false }, this._resizeAll);
     this.indexLogs();
     let results = this.index.search(`${query}*`);
     this.setState({ results }, this._resizeSearchResults);
-    console.log("search results: ", results);
+    logger.info("search results: ", results);
   };
 
   listenForEnter = (key) => {
@@ -153,7 +154,7 @@ class StreamContainer extends React.Component {
 
   indexLogs = () => {
     const { logs } = this.state;
-    console.log("indexing", logs.length, "logs for search");
+    logger.info("indexing", logs.length, "logs for search");
     this.index = lunr(function () {
       this.field("filename");
       this.field("funcName");

--- a/src/components/Settings/Settings.jsx
+++ b/src/components/Settings/Settings.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { logger } from "../../logger";
 import PropTypes from "prop-types";
 import {
   Card,
@@ -38,7 +39,7 @@ class SettingsCard extends React.Component {
       updates[setting] = value;
       return { updates };
     });
-    console.log("updates: ", this.state.updates);
+    logger.info("updates: ", this.state.updates);
   };
 
   saveChanges = () => {

--- a/src/flux/api.js
+++ b/src/flux/api.js
@@ -1,5 +1,9 @@
 import axios from "axios";
 import { hubURL } from "./config";
+import { logger } from "../logger";
+
+const moduleLogger = logger.child({ module: "api.js" });
+
 let logStream;
 let taskStream;
 
@@ -15,18 +19,18 @@ const hub = axios.create({
 
 export default {
   checkConnection: (settings) => {
-    console.log("checking connection");
+    moduleLogger.info("checking connection");
     let connectionString = `${settings.host}:${settings.port}${
       settings.ready.startsWith("/") ? settings.ready : "/" + settings.ready
     }`;
-    console.log("checkConnection string:", connectionString);
+    moduleLogger.info("checkConnection string:", connectionString);
     return axios.get(connectionString);
   },
   connect: (settings, logUpdate, taskUpdate) => {
     const logString = `${settings.host}:${settings.port}${
       settings.log.startsWith("/") ? settings.log : "/" + settings.log
     }`;
-    console.log("logs connectionString: ", logString);
+    moduleLogger.info("logs connectionString: ", logString);
     if (logStream) logStream.close();
     logStream = new EventSource(logString);
 
@@ -52,7 +56,7 @@ export default {
         ? settings.profile
         : "/" + settings.profile
     }`;
-    console.log("task connectionString:", taskString);
+    moduleLogger.info("task connectionString:", taskString);
     if (taskStream) taskStream.close();
     taskStream = new EventSource(taskString);
 
@@ -78,32 +82,32 @@ export default {
     return result.data;
   },
   getYAML: async (connectionString) => {
-    console.log("YAML connectionString: ", connectionString);
+    moduleLogger.info("YAML connectionString: ", connectionString);
     const result = await axios.get(connectionString);
     return result.data;
   },
   getImages: async () => {
-    console.log("get images...");
+    moduleLogger.info("get images...");
     const result = await hub.get("images");
     return result.data;
   },
   getImage: async (id) => {
-    console.log("get image", id);
+    moduleLogger.info("get image", id);
     const result = await hub.get(`/images/${id}`);
     return result.data;
   },
   postRating: async (imageId, stars) => {
-    console.log("post rating", imageId, stars);
+    moduleLogger.info("post rating", imageId, stars);
     const result = await hub.post(`/images/${imageId}/ratings`, { stars });
     return result.data;
   },
   postReview: async (imageId, content) => {
-    console.log("post review", imageId, content);
+    moduleLogger.info("post review", imageId, content);
     const result = await hub.post(`/images/${imageId}/reviews`, { content });
     return result.data;
   },
   searchHub: async (category, q, sort) => {
-    console.log("search hub", category, q, sort);
+    moduleLogger.info("search hub", category, q, sort);
     const result = await hub.get(
       `/images?category=${category}&q=${q}&sort=${sort}`
     );

--- a/src/flux/store.js
+++ b/src/flux/store.js
@@ -1,4 +1,5 @@
 import { EventEmitter } from "events";
+import { logger } from "../logger";
 import Dispatcher from "./dispatcher";
 import Constants from "./constants";
 import { parseYAML, formatForFlowchart, formatSeconds } from "../helpers";
@@ -168,15 +169,15 @@ class Store extends EventEmitter {
     } catch (e) {
       this.connected = false;
     }
-    console.log("prevStatus:", prevStatus, "connected:", this.connected);
+    logger.info("prevStatus:", prevStatus, "connected:", this.connected);
     if (prevStatus !== this.connected) return this.init();
   };
 
   init = async () => {
     this.clearIntervals();
     _store = getInitialStore();
-    
-    console.log("settings: ", _store.settings);
+
+    logger.info("settings: ", _store.settings);
 
     this.startNetworkMonitor();
     await this.initFlowChart();
@@ -208,7 +209,7 @@ class Store extends EventEmitter {
     const { settings } = _store;
     const connectionString = `${settings.host}:${settings.port}${
       settings.yaml.startsWith("/") ? settings.yaml : "/" + settings.yaml
-      }`;
+    }`;
 
     if (yamlSTRING) {
       flow = parseYAML(yamlSTRING);
@@ -237,12 +238,12 @@ class Store extends EventEmitter {
     try {
       canvas = flow.data.with.board.canvas;
     } catch (e) {
-      console.log("could not find canvas");
+      logger.info("could not find canvas");
       canvas = {};
     }
-    console.log("pods: ", flow.data.pods);
+    logger.info("pods: ", flow.data.pods);
     const parsed = formatForFlowchart(flow.data.pods, canvas);
-    console.log("parsed: ", parsed);
+    logger.info("parsed: ", parsed);
     parsed.with = flow.data.with;
     _store.flowchart = parsed;
     this.emit("update-ui");
@@ -384,8 +385,8 @@ class Store extends EventEmitter {
       _store.summaryCharts[level] = new Array(NUM_CHART_ELEMENTS).fill(0);
     }
     _store.occurences.lastLog = new Array(NUM_CHART_ELEMENTS).fill({});
-    console.log("initial Occurences: ", _store.occurences);
-    console.log("initial summary charts: ", _store.summaryCharts);
+    logger.info("initial Occurences: ", _store.occurences);
+    logger.info("initial summary charts: ", _store.summaryCharts);
     this.updateChartInterval = setInterval(
       this.updateSummaryCharts,
       CHART_UPDATE_INTERVAL
@@ -405,7 +406,7 @@ class Store extends EventEmitter {
 
   initUser = async () => {
     const user = await api.getProfile();
-    console.log("user", user);
+    logger.info("user", user);
     _store.user = user;
     this.emit("update-user");
   };
@@ -422,7 +423,7 @@ class Store extends EventEmitter {
     }
     _store.occurences.lastLog.push(_store.logs.length - 1);
     _store.occurences.lastLog.shift();
-    // console.log('summaryCharts:', _store.summaryCharts);
+    // logger.info('summaryCharts:', _store.summaryCharts);
     this.emit("update-summary-chart");
   };
 
@@ -436,9 +437,9 @@ class Store extends EventEmitter {
   }
 
   showLogAtIndex = (index) => {
-    console.log("index: ", index);
+    logger.info("index: ", index);
     let logIndex = _store.occurences.lastLog[index];
-    console.log("logIndex: ", logIndex);
+    logger.info("logIndex: ", logIndex);
     if (!logIndex) return;
     _store.logIndex = _store.occurences.lastLog[index];
     this.emit("show-log");
@@ -458,7 +459,7 @@ class Store extends EventEmitter {
   };
 
   postRating = async ({ imageId, stars }) => {
-    console.log("posting rating: ", imageId, stars);
+    logger.info("posting rating: ", imageId, stars);
     if (!_store.user) return (window.location.hash = "#/login");
     let result;
     try {
@@ -505,7 +506,7 @@ class Store extends EventEmitter {
 
   searchHub = async ({ category, q, sort }) => {
     const images = await api.searchHub(category, q, sort);
-    console.log("found", images.length, "images");
+    logger.info("found", images.length, "images");
     _store.hub = images;
     this.emit("update-hub");
   };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,7 @@
 const YAML = require("yaml");
 const settings = require("./settings");
 const propertyList = require("./data/properties.json");
+const { logger } = require("./logger");
 
 const propertyTypes = {};
 propertyList.forEach((prop) => (propertyTypes[prop.name] = prop.type));
@@ -17,7 +18,7 @@ export function copyToClipboard(str) {
 export function parseYAML(yamlSTR) {
   try {
     const data = YAML.parse(yamlSTR);
-    console.log("data:", data);
+    logger.info("data:", data);
     return { data };
   } catch (error) {
     alert("Error Parsing YAML:\n" + error);
@@ -124,7 +125,7 @@ export function formatForFlowchart(pods, canvas) {
 }
 
 export function formatAsYAML(chart) {
-  console.log("formatAsYAML input: ", chart);
+  logger.info("formatAsYAML input: ", chart);
   let output = {
     with: chart.with || {},
     pods: {},
@@ -198,14 +199,14 @@ function getNodeDepth(nodes, currentId, currentDepth) {
   let parents = Object.keys(nodes[currentId].needs);
   let longestDepth = 0;
 
-  // console.log('nodes: ',nodes)
-  // console.log('currentId: ',currentId);
-  // console.log('parents: ',parents);
-  // console.log('currentDepth: ',currentDepth);
+  // logger.info('nodes: ',nodes)
+  // logger.info('currentId: ',currentId);
+  // logger.info('parents: ',parents);
+  // logger.info('currentDepth: ',currentDepth);
 
   for (let i = 0; i < parents.length; ++i) {
     let parent = parents[i];
-    console.log("\tparent:", parent);
+    logger.info("\tparent:", parent);
     let depth;
     if (nodes[parent].depth) depth = nodes[parent].depth + 1;
     else depth = getNodeDepth(nodes, parent, 1);

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,5 @@
+import pino from "pino";
+
+const logger = pino();
+
+export { logger };

--- a/src/views/FlowView.jsx
+++ b/src/views/FlowView.jsx
@@ -14,11 +14,12 @@ import {
 import { Dispatcher, Constants, Store } from "../flux";
 import PageTitle from "../components/Common/PageTitle";
 
-import CommandBar from '../components/FlowChart/CommandBar';
+import CommandBar from "../components/FlowChart/CommandBar";
 import Sidebar from "../components/FlowChart/Sidebar";
 import CustomNode from "../components/FlowChart/ChartNode";
 import CustomPort from "../components/FlowChart/NodePort";
 import { formatAsYAML, copyToClipboard } from "../helpers";
+import { logger } from "../logger";
 
 class FlowTab extends React.Component {
   constructor(props) {
@@ -27,7 +28,7 @@ class FlowTab extends React.Component {
     const banner = Store.getBanner("flow");
     this.state = { chart, banner };
 
-    console.log("actions:", actions);
+    logger.info("actions:", actions);
     this.stateActionCallbacks = Object.keys(actions).reduce((obj, key, idx) => {
       obj[key] = (...args) => {
         let { chart } = this.state;
@@ -68,7 +69,7 @@ class FlowTab extends React.Component {
   updateNode = (node, callback) => {
     let { chart } = this.state;
     let newChart = cloneDeep(chart);
-    console.log("newChart: ", newChart);
+    logger.info("newChart: ", newChart);
     newChart.nodes[node.id].label = node.label;
 
     let props = {
@@ -178,8 +179,8 @@ class FlowTab extends React.Component {
             <Card className="chart-section-container p-1 mr-md-4 mb-4">
               <div className="chart-container">
                 <CommandBar
-                copyChart={this.copyChartAsYAML}
-                importChart={this.showImportModal}
+                  copyChart={this.copyChartAsYAML}
+                  importChart={this.showImportModal}
                 />
                 <FlowChart
                   chart={chart}

--- a/src/views/LogIn.jsx
+++ b/src/views/LogIn.jsx
@@ -4,34 +4,35 @@ import { hubURL } from "../flux/config";
 
 import React from "react";
 import { Link } from "react-router-dom";
+import { logger } from "../logger";
 import { Container, Row, Col, Card, CardBody } from "shards-react";
 
 class Login extends React.Component {
   componentDidMount = () => {
     let hash = window.location.href;
     if (hash.indexOf("code") > 0) {
-      console.log("hash: ", hash);
+      logger.info("hash: ", hash);
       let code = hash.substring(hash.indexOf("code") + 5, hash.length);
-      console.log("code:", code);
+      logger.info("code:", code);
       window.location = `${hubURL}/auth/github/callback?code=${code}`;
     }
   };
   testAuthentication = () => {
     const xhr = new XMLHttpRequest();
     const connectionString = `${hubURL}/auth/test`;
-    console.log("test connectionString: ", connectionString);
+    logger.info("test connectionString: ", connectionString);
     xhr.open("POST", connectionString);
     xhr.timeout = 5000;
     xhr.withCredentials = true;
     xhr.onload = function () {
       if (this.status >= 200 && this.status < 300) {
-        console.log("test: SUCCESS");
+        logger.info("test: SUCCESS");
       } else {
-        console.log("test: FAIL");
+        logger.info("test: FAIL");
       }
     };
     xhr.onerror = function () {
-      console.log("test: ERROR");
+      logger.info("test: ERROR");
     };
     xhr.send();
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2450,6 +2450,11 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+atomic-sleep@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
+  integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
+
 autoprefixer@^9.6.1:
   version "9.8.5"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.8.5.tgz#2c225de229ddafe1d1424c02791d0c3e10ccccaa"
@@ -5215,6 +5220,16 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-redact@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-2.0.0.tgz#17bb8f5e1f56ecf4a38c8455985e5eab4c478431"
+  integrity sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA==
+
+fast-safe-stringify@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
+  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
+
 fault@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.4.tgz#eafcfc0a6d214fc94601e170df29954a4f842f13"
@@ -5434,6 +5449,11 @@ flat-cache@^2.0.1:
     flatted "^2.0.0"
     rimraf "2.6.3"
     write "1.0.3"
+
+flatstr@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.12.tgz#c2ba6a08173edbb6c9640e3055b95e287ceb5931"
+  integrity sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==
 
 flatted@^2.0.0:
   version "2.0.2"
@@ -9165,6 +9185,23 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
+pino-std-serializers@^2.4.2:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-2.5.0.tgz#40ead781c65a0ce7ecd9c1c33f409d31fe712315"
+  integrity sha512-wXqbqSrIhE58TdrxxlfLwU9eDhrzppQDvGhBEr1gYbzzM4KKo3Y63gSjiDXRKLVS2UOXdPNR2v+KnQgNrs+xUg==
+
+pino@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-6.5.1.tgz#a245adf960a1f3e88e61a339045d509bccbfb7cc"
+  integrity sha512-76+RUhQkqjUD4AtQcSfEzh6vlsjXmoWZK5gg+2d70aCLXZTbo4/5js4I9rN1Xk6z1h2/7pnOFX10G4c2T4qNiA==
+  dependencies:
+    fast-redact "^2.0.0"
+    fast-safe-stringify "^2.0.7"
+    flatstr "^1.0.12"
+    pino-std-serializers "^2.4.2"
+    quick-format-unescaped "^4.0.1"
+    sonic-boom "^1.0.2"
+
 pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
@@ -10174,6 +10211,11 @@ querystringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
+
+quick-format-unescaped@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz#437a5ea1a0b61deb7605f8ab6a8fd3858dbeb701"
+  integrity sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==
 
 raf@^3.4.1:
   version "3.4.1"
@@ -11518,6 +11560,14 @@ sockjs@0.3.19:
   dependencies:
     faye-websocket "^0.10.0"
     uuid "^3.0.1"
+
+sonic-boom@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-1.1.0.tgz#538c2de63aaca1b49254a7ed9d16e4931fab6ad3"
+  integrity sha512-JyOf+Xt7GBN4tAic/DD1Bitw6OMgSHAnswhPeOiLpfRoSjPNjEIi73UF3OxHzhSNn9WavxGuCZzprFCGFSNwog==
+  dependencies:
+    atomic-sleep "^1.0.0"
+    flatstr "^1.0.12"
 
 sort-keys@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
The PR introduces a dedicated package for logging and replaces all console.log statements found in the `src` folder with calls to a logger instance. As a first step, all console.logs just have been replaced with a message on level `info`.

Disadvantages of `console.log` in production:
- considerable impact on performance
- cannot be turned off in a single place 
- cannot be controlled on level 
- cannot be routed to other destinations (remote endpoint, or local server, that logs to a file instead of browser console)

In the near future, it might be a good idea to add a small local server (similar to the currently used `testServer`), that is started when dashboard is started with a `debug` flag. This will make it possible to log to a file.
Issue templates could ask the user to start the dashboard in debug mode and attach the logfile.

The current PR is only a first step. 
In the near future it might be a good idea to further
- cleanup all current `console.log` (now `logger.info`) and remove some leftovers that don't belong into the code
- assign appropriate levels to the remaining messages
- add context via childloggers to the messages


