### PR TITLE
Decompose Settings .jsx into small components

### DIFF
--- a/src/components/Settings/FormItem.jsx
+++ b/src/components/Settings/FormItem.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Col, FormInput } from "shards-react";
+
+export default function FormItem({
+  colSpan = 6,
+  label,
+  value,
+  placeholder,
+  onChange,
+}) {
+  return (
+    <Col md={colSpan} className="form-group">
+      <label>{label}</label>
+      <FormInput placeholder={placeholder} value={value} onChange={onChange} />
+    </Col>
+  );
+}

--- a/src/components/Settings/Settings.jsx
+++ b/src/components/Settings/Settings.jsx
@@ -1,171 +1,104 @@
-import React from "react";
-import {
-  Card,
-  CardHeader,
-  CardBody,
-  Row,
-  Col,
-  Form,
-  FormInput,
-} from "shards-react";
+import React, { useState, useEffect } from "react";
+import { Card, CardHeader, CardBody, Row, Form } from "shards-react";
 import { Collapse } from "react-bootstrap";
 
-import { Store, Dispatcher, Constants } from "../../flux";
+import {
+  Store,
+  /* Dispatcher,
+  Constants, */
+} from "../../flux";
+import { baseOptions, advancedOptions } from "./options";
+import FormItem from "./FormItem";
 
-class SettingsCard extends React.Component {
-  constructor() {
-    super();
-    this.state = {
-      original: Store.getSettings(),
-      updates: {},
-      expanded: false,
-    };
-    Store.on("update-settings", this.getData);
+function SettingsCard() {
+  const [original, setOriginal] = useState(Store.getSettings());
+  const [updates, setUpdates] = useState({});
+  const [expanded, setExpanded] = useState(false);
+
+  function getData() {
+    const original = Store.getSettings();
+    setOriginal(original);
+    setUpdates({});
   }
 
-  componentWillUnmount = () => {
-    Store.removeListener("update-settings", this.getData);
-  };
+  useEffect(() => {
+    Store.on("update-settings", getData);
 
-  getData = () => {
-    const original = Store.getSettings();
-    this.setState({ original, updates: {} });
-  };
+    return function cleanup() {
+      Store.removeListener("update-settings", getData);
+    };
+  }, []);
 
-  updateSetting = (setting, value) => {
-    this.setState((prevState) => {
-      let { updates } = prevState;
-      updates[setting] = value;
-      return { updates };
-    });
-  };
+  function updateSetting(setting, value) {
+    const newUpdates = { ...updates };
+    newUpdates[setting] = value;
+    setUpdates(newUpdates);
+  }
 
-  saveChanges = () => {
-    const { original, updates } = this.state;
-
+  /** unused function 
+  function saveChanges(){
     const settings = { ...original, ...updates };
 
     Dispatcher.dispatch({
       actionType: Constants.SAVE_SETTINGS,
       payload: settings,
     });
-  };
+  }
+  */
 
-  toggleExpand = () => {
-    this.setState({ expanded: !this.state.expanded });
-  };
+  function toggleExpand() {
+    setExpanded(!expanded);
+  }
 
-  render = () => {
-    const { original, updates, expanded } = this.state;
-    console.log("expanded:", expanded);
-    return (
-      <Card small className="mb-4">
-        <CardHeader className="border-bottom">
-          <h6 className="m-0">Connection Preferences</h6>
-        </CardHeader>
-        <CardBody>
-          <Form>
-            <Row form>
-              <Col md="6" className="form-group">
-                <label>Host</label>
-                <FormInput
-                  placeholder="0.0.0.0"
-                  value={"host" in updates ? updates.host : original.host}
-                  onChange={(e) => this.updateSetting("host", e.target.value)}
-                />
-              </Col>
-              <Col md="6" className="form-group">
-                <label>Port</label>
-                <FormInput
-                  placeholder="5000"
-                  value={"port" in updates ? updates.port : original.port}
-                  onChange={(e) => this.updateSetting("port", e.target.value)}
-                />
-              </Col>
-            </Row>
-            <strong
-              aria-controls="collapsed-form"
-              aria-expanded={expanded}
-              onClick={this.toggleExpand}
-              className="text-primary d-block mb-3 cursor-pointer"
-            >
-              Advanced{" "}
-              <i className="material-icons">
-                {expanded ? "arrow_drop_up" : "arrow_drop_down"}
-              </i>
-            </strong>
-            <Collapse in={expanded}>
-              <div id="collapsed-form">
-                <strong className="text-muted d-block mb-3">Endpoints</strong>
-                <Row form>
-                  <Col md="6" className="form-group">
-                    <label>Log</label>
-                    <FormInput
-                      placeholder="/stream/log"
-                      value={"log" in updates ? updates.log : original.log}
-                      onChange={(e) =>
-                        this.updateSetting("log", e.target.value)
-                      }
-                    />
-                  </Col>
-                  <Col md="6" className="form-group">
-                    <label>Profile</label>
-                    <FormInput
-                      placeholder="/stream/profile"
-                      value={
-                        "profile" in updates
-                          ? updates.profile
-                          : original.profile
-                      }
-                      onChange={(e) =>
-                        this.updateSetting("profile", e.target.value)
-                      }
-                    />
-                  </Col>
-                  <Col md="6" className="form-group">
-                    <label>YAML</label>
-                    <FormInput
-                      placeholder="/data/yaml"
-                      value={"yaml" in updates ? updates.yaml : original.yaml}
-                      onChange={(e) =>
-                        this.updateSetting("yaml", e.target.value)
-                      }
-                    />
-                  </Col>
-                  <Col md="6" className="form-group">
-                    <label>Shutdown</label>
-                    <FormInput
-                      placeholder="/action/shutdown"
-                      value={
-                        "shutdown" in updates
-                          ? updates.shutdown
-                          : original.shutdown
-                      }
-                      onChange={(e) =>
-                        this.updateSetting("shutdown", e.target.value)
-                      }
-                    />
-                  </Col>
-                  <Col md="6" className="form-group">
-                    <label>Ready</label>
-                    <FormInput
-                      placeholder="/status/isready"
-                      value={
-                        "ready" in updates ? updates.ready : original.ready
-                      }
-                      onChange={(e) =>
-                        this.updateSetting("ready", e.target.value)
-                      }
-                    />
-                  </Col>
-                </Row>
-              </div>
-            </Collapse>
-          </Form>
-        </CardBody>
-      </Card>
-    );
-  };
+  return (
+    <Card small className="mb-4">
+      <CardHeader className="border-bottom">
+        <h6 className="m-0">Connection Preferences</h6>
+      </CardHeader>
+      <CardBody>
+        <Form>
+          <Row form>
+            {baseOptions.map(({ label, placeholder, value }) => (
+              <FormItem
+                key={value}
+                label={label}
+                placeholder={placeholder}
+                value={value in updates ? updates[value] : original[value]}
+                onChange={(e) => updateSetting(value, e.target.value)}
+              />
+            ))}
+          </Row>
+          <strong
+            aria-controls="collapsed-form"
+            aria-expanded={expanded}
+            onClick={toggleExpand}
+            className="text-primary d-block mb-3 cursor-pointer"
+          >
+            Advanced{" "}
+            <i className="material-icons">
+              {expanded ? "arrow_drop_up" : "arrow_drop_down"}
+            </i>
+          </strong>
+          <Collapse in={expanded}>
+            <div id="collapsed-form">
+              <strong className="text-muted d-block mb-3">Endpoints</strong>
+              <Row form>
+                {advancedOptions.map(({ label, placeholder, value }) => (
+                  <FormItem
+                    key={value}
+                    label={label}
+                    placeholder={placeholder}
+                    value={value in updates ? updates[value] : original[value]}
+                    onChange={(e) => updateSetting(value, e.target.value)}
+                  />
+                ))}
+              </Row>
+            </div>
+          </Collapse>
+        </Form>
+      </CardBody>
+    </Card>
+  );
 }
 
 export default SettingsCard;

--- a/src/components/Settings/options.js
+++ b/src/components/Settings/options.js
@@ -1,0 +1,40 @@
+export const baseOptions = [
+  {
+    label: "Host",
+    placeholder: "0.0.0.0",
+    value: "host",
+  },
+  {
+    label: "Port",
+    placeholder: "5000",
+    value: "port",
+  },
+];
+
+export const advancedOptions = [
+  {
+    label: "Log",
+    placeholder: "/stream/log",
+    value: "log",
+  },
+  {
+    label: "Profile",
+    placeholder: "/stream/profile",
+    value: "profile",
+  },
+  {
+    label: "YAML",
+    placeholder: "/data/yaml",
+    value: "yaml",
+  },
+  {
+    label: "Shutdown",
+    placeholder: "/action/shutdown",
+    value: "shutdown",
+  },
+  {
+    label: "Ready",
+    placeholder: "/status/isready",
+    value: "ready",
+  },
+];


### PR DESCRIPTION
- break settings.jsx to use a composite element of label and form input
- separate the form element details into base option and advance option list
- change from class to hooks
- commented out unused function `saveChanges`