### PR TITLE
add linting pre commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
-    "format": "prettier --write \"src/**/*.{js,jsx, ts, tsx}\""
+    "format": "prettier --write \"src/**/*.{js,jsx, ts, tsx}\"",
+    "lint": "eslint \"src/**/*.{js,jsx, ts, tsx}\" --max-warnings=0"
   },
   "husky": {
     "hooks": {
@@ -65,7 +66,8 @@
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
-      "prettier --write"
+      "prettier --write",
+      "eslint --max-warnings=0"
     ]
   },
   "eslintConfig": {


### PR DESCRIPTION
This prevents files with linter warnings from being committed. 
As a next step, we run linting per github actions as part of the CI but I think the precommit hook is a good first step to introduce this. We should go with it for a week before linting as part of the actual build pipeline, so it can break the build.
It can be overridden.

