### PR TITLE
Feat: debug mode

### DIFF
--- a/src/components/Layout/MainFooter.jsx
+++ b/src/components/Layout/MainFooter.jsx
@@ -1,7 +1,14 @@
 import React from "react";
 import { Container, Row, Nav } from "shards-react";
 
-const MainFooter = ({ menuItems, copyright }) => (
+const MainFooter = ({
+  menuItems,
+  copyright,
+  loggerEnabled,
+  enableLogger,
+  disableLogger,
+  exportLogs,
+}) => (
   <footer className="main-footer d-flex p-2 px-3 bg-white border-top">
     <Container fluid>
       <Row>
@@ -11,6 +18,29 @@ const MainFooter = ({ menuItems, copyright }) => (
               {item.title}
             </a>
           ))}
+          {loggerEnabled ? (
+            <>
+              <span
+                className="nav-link text-warning cursor-pointer"
+                onClick={disableLogger}
+              >
+                Exit Debug Mode
+              </span>
+              <span
+                className="nav-link text-warning cursor-pointer"
+                onClick={exportLogs}
+              >
+                Export Debug Data
+              </span>
+            </>
+          ) : (
+            <span
+              className="nav-link text-warning cursor-pointer"
+              onClick={enableLogger}
+            >
+              Debug Mode
+            </span>
+          )}
         </Nav>
         <span className="copyright ml-auto my-auto mr-2">{copyright}</span>
       </Row>

--- a/src/flux/api.js
+++ b/src/flux/api.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import logger from "../logger";
 import { hubURL, timeout } from "./config";
 let logStream;
 let taskStream;
@@ -15,13 +16,18 @@ const hub = axios.create({
 
 export default {
   connect: (settings, connectionUpdate, logUpdate, taskUpdate) => {
+    logger.log("api - connect - settings", settings);
+
     const logString = `${settings.host}:${settings.port}${
       settings.log.startsWith("/") ? settings.log : "/" + settings.log
     }`;
+    logger.log("api - connect - logString", logString);
+
     if (logStream) logStream.close();
     logStream = new EventSource(logString);
 
     logStream.onopen = () => {
+      logger.log("api - logStream.onopen called");
       connectionUpdate(
         "connected",
         `Logserver connection established at ${settings.host}:${settings.port}`
@@ -33,11 +39,11 @@ export default {
     };
 
     logStream.onerror = (data) => {
+      logger.log("api - logStream.onerror - ERROR", data);
       connectionUpdate(
         "failed",
         `Could not connect to logserver at ${settings.host}:${settings.port}`
       );
-      console.error("log error: ", data);
       logStream.close();
     };
 
@@ -46,10 +52,13 @@ export default {
         ? settings.profile
         : "/" + settings.profile
     }`;
+    logger.log("api - connect - taskString", taskString);
+
     if (taskStream) taskStream.close();
     taskStream = new EventSource(taskString);
 
     taskStream.onopen = () => {
+      logger.log("api - taskStream.onopen called");
       taskUpdate({
         type: "connect",
         data: `Task connection established at ${taskString}`,
@@ -61,11 +70,11 @@ export default {
     };
 
     taskStream.onerror = (data) => {
+      logger.log("api - taskStream.onerror - ERROR", data);
       taskUpdate({
         type: "error",
         data: `Could not get profile data from ${taskString}`,
       });
-      console.error("task error:", data);
       taskStream.close();
     };
   },
@@ -74,6 +83,7 @@ export default {
     return result.data;
   },
   getYAML: async (connectionString) => {
+    logger.log("api - getYAML - connectionString", connectionString);
     const result = await axios.get(connectionString, { timeout });
     return result.data;
   },

--- a/src/flux/store.js
+++ b/src/flux/store.js
@@ -4,6 +4,7 @@ import Dispatcher from "./dispatcher";
 import Constants from "./constants";
 import { parseYAML, formatForFlowchart, formatSeconds } from "../helpers";
 import api from "./api";
+import logger from "../logger";
 import propertyList from "../data/podProperties.json";
 import getSidebarNavItems from "../data/sidebar-nav-items";
 import exampleYAML from "../data/yaml";
@@ -108,6 +109,8 @@ function getInitialStore() {
     currentTab: "logStream",
   };
 }
+
+if (window.location.hostname === "localhost") logger.enable();
 
 class Store extends EventEmitter {
   constructor() {

--- a/src/flux/store.js
+++ b/src/flux/store.js
@@ -1,5 +1,6 @@
 import { EventEmitter } from "events";
 import { nanoid } from "nanoid";
+import _ from "lodash";
 import Dispatcher from "./dispatcher";
 import Constants from "./constants";
 import { parseYAML, formatForFlowchart, formatSeconds } from "../helpers";
@@ -189,6 +190,7 @@ class Store extends EventEmitter {
   };
 
   initFlowChart = async (yamlSTRING) => {
+    logger.log("initFlowChart - yamlString", yamlSTRING);
     let flow;
     const { settings } = _store;
     const connectionString = `${settings.host}:${settings.port}${
@@ -202,6 +204,7 @@ class Store extends EventEmitter {
         let str = await api.getYAML(connectionString);
         flow = parseYAML(str);
       } catch (e) {
+        logger.log("initFlowChart - parseYAML[API] ERROR", e);
         return;
       }
     }
@@ -211,6 +214,8 @@ class Store extends EventEmitter {
     } catch (e) {
       canvas = {};
     }
+    logger.log("initFlowChart - flow", flow);
+    logger.log("initFlowChart - canvas", canvas);
     const parsed = formatForFlowchart(flow.data.pods, canvas);
     parsed.with = flow.data.with;
     _store.flowchart = parsed;
@@ -232,6 +237,8 @@ class Store extends EventEmitter {
   };
 
   handleLogConnectionStatus = (status, message) => {
+    logger.log("handleLogConnectionStatus - status", status);
+    logger.log("handleLogConnectionStatus - message", message);
     _store.loading = false;
     if (status === "connected") {
       _store.connected = true;
@@ -408,6 +415,7 @@ class Store extends EventEmitter {
   };
 
   importCustomYAML = (customYAML) => {
+    logger.log("importCustomYAML - customYAML", customYAML);
     this.initFlowChart(customYAML);
     this.closeModal();
     this.emit("update-flowchart");
@@ -420,6 +428,7 @@ class Store extends EventEmitter {
   };
 
   saveSettings = (settings) => {
+    logger.log("saveSettings - settings", settings);
     Object.keys(settings).forEach((key) => {
       localStorage.setItem(`preferences-${key}`, settings[key]);
     });
@@ -612,6 +621,10 @@ class Store extends EventEmitter {
 
   getIndexedLog = () => {
     return _store.logIndex;
+  };
+
+  getStoreCopy = () => {
+    return _.cloneDeep(_store);
   };
 }
 

--- a/src/layouts/IconSidebar.jsx
+++ b/src/layouts/IconSidebar.jsx
@@ -11,12 +11,15 @@ import ConnectionBanner from "../components/Common/ConnectionBanner";
 import PasteYAML from "../modals/PasteYAML";
 import WriteReview from "../modals/WriteReview";
 
+import logger from "../logger";
+
 import { Store, Dispatcher, Constants } from "../flux";
 
 class IconSidebarLayout extends React.Component {
   constructor() {
     super();
     this.state = {
+      loggerEnabled: logger.isEnabled(),
       modal: Store.getModal(),
       loading: Store.isLoading(),
       banner: Store.getBanner(),
@@ -35,7 +38,8 @@ class IconSidebarLayout extends React.Component {
     const loading = Store.isLoading();
     const banner = Store.getBanner();
     const connected = Store.getConnectionStatus();
-    this.setState({ modal, loading, banner, connected });
+    const loggerEnabled = logger.isEnabled();
+    this.setState({ modal, loading, banner, connected, loggerEnabled });
   };
 
   acceptCookies = () => {
@@ -71,8 +75,38 @@ class IconSidebarLayout extends React.Component {
     });
   };
 
+  enableLogger = () => {
+    logger.enable();
+    Dispatcher.dispatch({
+      actionType: Constants.SHOW_BANNER,
+      payload: [
+        'Debug Mode Enabled. Click "Export Debug Data" to download Debug JSON.',
+        "warning",
+      ],
+    });
+  };
+
+  disableLogger = () => {
+    logger.disable();
+    Dispatcher.dispatch({
+      actionType: Constants.SHOW_BANNER,
+      payload: ["Debug Mode Disabled.", "warning"],
+    });
+  };
+
+  exportLogs = () => {
+    logger.exportLogs();
+  };
+
   render = () => {
-    const { modal, acceptedCookies, banner, connected, loading } = this.state;
+    const {
+      modal,
+      acceptedCookies,
+      banner,
+      connected,
+      loading,
+      loggerEnabled,
+    } = this.state;
     const { children } = this.props;
     return (
       <Container fluid className="icon-sidebar-nav">
@@ -91,7 +125,12 @@ class IconSidebarLayout extends React.Component {
               show={!acceptedCookies}
               acceptCookies={this.acceptCookies}
             />
-            <MainFooter />
+            <MainFooter
+              loggerEnabled={loggerEnabled}
+              enableLogger={this.enableLogger}
+              disableLogger={this.disableLogger}
+              exportLogs={this.exportLogs}
+            />
           </Col>
         </Row>
         <PasteYAML

--- a/src/layouts/IconSidebar.jsx
+++ b/src/layouts/IconSidebar.jsx
@@ -77,6 +77,8 @@ class IconSidebarLayout extends React.Component {
 
   enableLogger = () => {
     logger.enable();
+    const storeCopy = Store.getStoreCopy();
+    logger.log("Store Snapshot", storeCopy);
     Dispatcher.dispatch({
       actionType: Constants.SHOW_BANNER,
       payload: [
@@ -95,6 +97,8 @@ class IconSidebarLayout extends React.Component {
   };
 
   exportLogs = () => {
+    const storeCopy = Store.getStoreCopy();
+    logger.log("Store Snapshot", storeCopy);
     logger.exportLogs();
   };
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,42 @@
+import { saveAs } from "file-saver";
+
+function handleErrorMessage(msg, url, line) {
+  logger.log("ERROR", msg, url, `line: ${line}`);
+}
+
+const logger = {
+  log: function () {
+    if (!window.logsEnabled) return;
+    let args = [...arguments];
+    console.log(...args);
+    window.logs.push(args);
+  },
+  enable: function () {
+    const _navigator = {};
+    for (let i in window.navigator) _navigator[i] = window.navigator[i];
+    window.logs = [];
+    window.logs.push(_navigator);
+    window.addEventListener("error", handleErrorMessage);
+    window.logsEnabled = true;
+  },
+  disable: function () {
+    window.removeEventListener("error", handleErrorMessage);
+    window.logsEnabled = false;
+  },
+  exportLogs: function () {
+    const format = window.logsFormat;
+    const logs = window.logs;
+    let content = "[\n";
+    for (let i = 0; i < logs.length; ++i) {
+      let args = logs[i];
+      content += JSON.stringify(args) + `${i < logs.length - 1 ? "," : ""}\n`;
+    }
+    content += "]";
+
+    let filename = `jina-dashboard-debug-output-${new Date()}.${format}`;
+    let blob = new Blob([content], { type: "text,plain;charset=utf-8" });
+    saveAs(blob, filename);
+  },
+};
+
+export default logger;

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,7 +1,7 @@
 import { saveAs } from "file-saver";
 
 function handleErrorMessage(msg, url, line) {
-  logger.log("ERROR", msg, url, `line: ${line}`);
+  logger.log("window.onerror - ERROR", msg, url, `line: ${line}`);
 }
 
 const logger = {

--- a/src/logger.js
+++ b/src/logger.js
@@ -11,6 +11,9 @@ const logger = {
     console.log(...args);
     window.logs.push(args);
   },
+  isEnabled: function () {
+    return window.logsEnabled;
+  },
   enable: function () {
     const _navigator = {};
     for (let i in window.navigator) _navigator[i] = window.navigator[i];
@@ -23,8 +26,11 @@ const logger = {
     window.removeEventListener("error", handleErrorMessage);
     window.logsEnabled = false;
   },
+  setFormat: function (format = "json") {
+    window.logsFormat = format;
+  },
   exportLogs: function () {
-    const format = window.logsFormat;
+    const format = window.logsFormat || "json";
     const logs = window.logs;
     let content = "[\n";
     for (let i = 0; i < logs.length; ++i) {

--- a/src/views/PackageView.jsx
+++ b/src/views/PackageView.jsx
@@ -57,7 +57,7 @@ class PackageView extends React.Component {
     copyToClipboard(content);
     Dispatcher.dispatch({
       actionType: Constants.SHOW_BANNER,
-      payload: ["hub", "Content copied to clipboard", "success"],
+      payload: ["Content copied to clipboard", "success"],
     });
   };
 


### PR DESCRIPTION
add `logger.js`
- only runs when enabled
- take snapshot of `window.navigator` to get browser information
- global error listener
- collect logs to array for export
- same usage as `console.log`, logs also piped to `console.log`
- export logs in JSON or TXT format (JSON by default)

implement `logger.js`
- enabled/disable, export logs via footer
- automatically enabled on `localhost`
- log key data areas: API actions, loading data
- log snapshot of store before exporting
