### PR TITLE
Increased width of hub select box by increasing 0.6em

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -711,7 +711,7 @@ code {
 .hub-select {
   height: auto !important;
   width: auto;
-  width: 10em;
+  width: 10.6em;
   max-width: 100%;
   display: inline-block;
   vertical-align: middle;


### PR DESCRIPTION
Current the dropdown in 100% screen zom break.
<img width="338" alt="Screenshot 2021-01-04 at 2 02 23 PM" src="https://user-images.githubusercontent.com/7305950/103515923-9b728780-4e95-11eb-9a94-a609fdb94e95.png">

Changed the size to fix:
<img width="371" alt="Screenshot 2021-01-04 at 2 02 58 PM" src="https://user-images.githubusercontent.com/7305950/103515946-a9c0a380-4e95-11eb-993c-8ff97ff0b102.png">
