### PR TITLE
Refactor: FlowView class component to functional component

### DIFF
--- a/cypress/integration/views/flowview.js
+++ b/cypress/integration/views/flowview.js
@@ -9,16 +9,9 @@ describe('The Flow Page', () => {
   context('When the dev server is connected', () => {
 
     it('should display the connection', () => {
-      cy.get('.mr-4 > .mb-0').contains('Logserver connection established at http://localhost:5000')
+      cy.dataName("connection-notification-body").contains('Logserver connection established at http://localhost:5000')
     })
 
-    it('should render Network Flow correctly', () => {
-      cy.get('.dropdown-toggle').click()
-      cy.get('.dropdown-menu > :nth-child(3)').click().then(() => {
-        const chart = Store.getFlowchart()
-        testChartRender(chart)
-      })
-    })
   })
 
   context('When a new flow is created', () => {
@@ -36,30 +29,4 @@ describe('The Flow Page', () => {
   })
 })
 
-function testNodeProperties(nodeProperties, nodeName)  {
-  const nodePropertyNames = Object.keys(nodeProperties)
-  nodePropertyNames.forEach((property) => {
-    if(typeof nodeProperties[property] === 'boolean') {
-      cy.get(`#chart-node-${nodeName} > .node-info`).contains(property + ':') //booleans should just get displayed as property names like 'log_see:'
-    }
-    else {
-      cy.get(`#chart-node-${nodeName} > .node-info`).contains(property + ':' + nodeProperties[property]) //for example yaml_path: /usr/local...
-    }
-  })
-}
 
-function testChartRender(chart) {
-  const nodes = chart.flow.nodes
-  const nodeNames = Object.keys(nodes)
-  nodeNames.forEach((nodeName) => {
-    cy.get(`#chart-node-${nodeName}`).then(() => {
-      cy.get(`#chart-node-${nodeName} > .node-header > .p-1`).contains(nodeName)  //test if nodeName is in Header
-      cy.get("body").then($body => {
-        if ($body.find(`#chart-node-${nodeName} > .node-info`).length > 0) {
-          const nodeProperties = nodes[nodeName].properties
-          testNodeProperties(nodeProperties, nodeName)
-        }
-      });
-    })
-  })
-}

--- a/src/components/Common/InfoToast.tsx
+++ b/src/components/Common/InfoToast.tsx
@@ -8,12 +8,12 @@ type Props = {
   };
 };
 
-function getIcon(theme:string){
-  if(theme==="success")
-    return <i className="material-icons mr-1">check_circle_outline</i>
-  else if(theme==="error")
-    return <i className="material-icons mr-1">cerror_outline</i>
-  return <i className="material-icons mr-1">warning</i>
+function getIcon(theme: string) {
+  if (theme === "success")
+    return <i className="material-icons mr-1">check_circle_outline</i>;
+  else if (theme === "error")
+    return <i className="material-icons mr-1">cerror_outline</i>;
+  return <i className="material-icons mr-1">warning</i>;
 }
 
 function InfoToast({ data }: Props) {
@@ -24,10 +24,16 @@ function InfoToast({ data }: Props) {
       <Toast className={`toast-${data.theme} text-white`}>
         <Toast.Header className="text-white" closeButton={false}>
           <strong className="mr-auto">
-            {icon}<span className="text-uppercase">{data.theme}</span>
+            {icon}
+            <span className="text-uppercase">{data.theme}</span>
           </strong>
         </Toast.Header>
-        <Toast.Body className="text-white">{data.message}</Toast.Body>
+        <Toast.Body
+          className="text-white"
+          data-name="connection-notification-body"
+        >
+          {data.message}
+        </Toast.Body>
       </Toast>
     </div>
   );

--- a/src/views/FlowView.tsx
+++ b/src/views/FlowView.tsx
@@ -1,22 +1,13 @@
-import React from "react";
-import { cloneDeep } from "lodash";
-import { FlowChart } from "@bastinjafari/react-flow-chart-with-tooltips-and-multi-select";
+import React, { useEffect, useState } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import {
+  selectFlowChart,
+  selectFlows,
+  selectSelectedFlowId,
+} from "../redux/flows/flows.selectors";
+import { Constants, Dispatcher, Store } from "../flux";
 import * as actions from "@bastinjafari/react-flow-chart-with-tooltips-and-multi-select/src/container/actions";
-import { Container, Row, Card } from "shards-react";
-import { Dispatcher, Constants, Store } from "../flux";
-import { PageTitle } from "../components/Common/PageTitle";
-import html2canvas from "html2canvas";
-
-import CommandBar from "../components/FlowChart/CommandBar";
-import Sidebar from "../components/FlowChart/Sidebar";
-import CustomNode from "../components/FlowChart/ChartNode";
-import CustomPort from "../components/FlowChart/NodePort";
-import FlowSelection from "../components/FlowChart/FlowSelection";
-import { formatAsYAML, copyToClipboard } from "../helpers";
-
-import Tooltip from "../components/FlowChart/Tooltip";
 import { tooltipConfig } from "../data/tooltipConfig";
-import { connect } from "react-redux";
 import {
   createNewFlow,
   deleteFlow,
@@ -24,76 +15,76 @@ import {
   loadFlow,
   updateFlow,
 } from "../redux/flows/flows.actions";
-import { State } from "../redux";
-import { Flow } from "../redux/flows/flows.types";
+import html2canvas from "html2canvas";
+import { cloneDeep } from "lodash";
+import { copyToClipboard, formatAsYAML } from "../helpers";
+import { Card, Container, Row } from "shards-react";
+import { PageTitle } from "../components/Common/PageTitle";
+import FlowSelection from "../components/FlowChart/FlowSelection";
+import CommandBar from "../components/FlowChart/CommandBar";
 import {
-  selectFlowChart,
-  selectFlows,
-  selectSelectedFlowId,
-} from "../redux/flows/flows.selectors";
+  FlowChart,
+  IChart,
+} from "@bastinjafari/react-flow-chart-with-tooltips-and-multi-select";
+import Tooltip from "../components/FlowChart/Tooltip";
+import CustomNode from "../components/FlowChart/ChartNode";
+import CustomPort from "../components/FlowChart/NodePort";
+import Sidebar from "../components/FlowChart/Sidebar";
 
-const syncEvents = [
-  "onDragNodeStop",
-  "onCanvasDrop",
-  "onCanvasClick",
-  "onNodeClick",
-  "onDragCanvasStop",
-  "updateNode",
-  "updateLink",
-];
+export default function FlowView() {
+  const dispatch = useDispatch();
+  const selectedFlowId = useSelector(selectSelectedFlowId);
+  const flows = useSelector(selectFlows);
+  const flowChart = useSelector(selectFlowChart);
+  const { flow: chart, type: flowType } = flowChart;
+  const chartWithTooltips = {
+    ...chart,
+    ...tooltipConfig,
+  };
+  const availableProperties = Store.getAvailableProperties();
+  const [connected, setConnected] = useState<boolean>(
+    Store.getConnectionStatus()
+  );
+  const [showOverlay, setShowOverlay] = useState<boolean>(false);
 
-class FlowView extends React.Component<any, any> {
-  constructor(props: any) {
-    super(props);
-    const selectedFlowId = props.selectedFlowId;
-    const flows = props.flows;
-    const connected = Store.getConnectionStatus();
-    const availableProperties = Store.getAvailableProperties();
-    this.state = {
-      availableProperties,
-      connected,
-      selectedFlowId,
-      flows,
-      showOverlay: false,
-      actionCallbacks: Object.keys(actions).reduce(
-        (obj: any, key: any, idx: any) => {
-          obj[key] = (...args: any) => {
-            let { chart } = this.props;
-            let action = (actions as any)[key];
-            let newChartTransformer = action(...args);
-            let newChart = newChartTransformer(chart);
-            this.updateFlow({ ...chart, ...newChart }, key);
-            return newChart;
-          };
-          return obj;
-        },
-        {}
-      ),
+  const actionCallbacks = Object.keys(actions).reduce((obj: any, key: any) => {
+    obj[key] = (...args: any) => {
+      let action = (actions as any)[key];
+      let newChartTransformer = action(...args);
+      let newChart = newChartTransformer(chart);
+      dispatch(updateFlow({ ...chartWithTooltips, ...newChart }));
+      return newChart;
     };
+    return obj;
+  }, {});
 
-    Store.on("update-ui", this.getConnectionStatus);
-    Store.on("update-flowchart", this.getData);
-  }
+  const getConnectionStatus = () => {
+    setConnected(Store.getConnectionStatus());
+  };
 
-  componentDidMount = () => {
+  Store.on("update-ui", getConnectionStatus);
+
+  useEffect(() => {
     const chartContainer = document.querySelector(".chart-container");
     if (chartContainer)
       chartContainer.addEventListener("contextmenu", (e) => e.preventDefault());
+    return () => {
+      Store.removeListener("update-ui", getConnectionStatus);
+    };
+  }, []);
+
+  const showCaptureOverlay = (showOverlay = true) => {
+    setShowOverlay(showOverlay);
   };
 
-  componentWillUnmount = () => {
-    Store.removeListener("update-flowchart", this.getData);
-    Store.removeListener("update-ui", this.getConnectionStatus);
-  };
-
-  exportImage = (extension = "png") => {
+  const exportImage = (extension = "png") => {
     const chartContainer = document.querySelector(".chart-container");
     const captureOverlay = document.querySelector(".capture-overlay");
     if (!chartContainer) return;
     if (captureOverlay) captureOverlay.classList.add("fade-out");
 
-    this.showCaptureOverlay();
-    setTimeout(() => this.showCaptureOverlay(false), 500);
+    showCaptureOverlay();
+    setTimeout(() => showCaptureOverlay(false), 500);
 
     let canvasParams = {
       foreignObjectRendering: true,
@@ -115,24 +106,7 @@ class FlowView extends React.Component<any, any> {
     });
   };
 
-  showCaptureOverlay = (showOverlay = true) => {
-    this.setState({ showOverlay });
-  };
-
-  getData = () => {
-    const { flow: chart, type: flowType } = this.props.flowChart;
-    const selectedFlowId = this.props.selectedFlowId;
-    const flows = this.props.flows;
-    this.setState({ chart, flowType, selectedFlowId, flows });
-  };
-
-  getConnectionStatus = () => {
-    const connected = Store.getConnectionStatus();
-    this.setState({ connected });
-  };
-
-  updateNode = (node: any) => {
-    let { chart } = this.state;
+  const updateNode = (node: any) => {
     let newChart = cloneDeep(chart);
     newChart.nodes[node.id].label = node.label;
 
@@ -148,174 +122,128 @@ class FlowView extends React.Component<any, any> {
     });
 
     newChart.nodes[node.id].properties = props;
+    dispatch(updateFlow({ ...chart, ...newChart }));
 
-    this.updateFlow({ ...chart, ...newChart }, "updateNode");
     return newChart.nodes[node.id];
   };
 
-  updateLink = (linkId: string, fromId: string, toId: string | undefined) => {
+  const updateLink = (
+    linkId: string,
+    fromId: string,
+    toId: string | undefined
+  ) => {
     if (fromId === toId) return;
-    let { chart } = this.state;
     let newChart = cloneDeep(chart);
 
     newChart.links[linkId].from.nodeId = fromId;
     newChart.links[linkId].to.nodeId = toId;
 
-    this.updateFlow({ ...chart, ...newChart }, "updateLink");
+    dispatch(updateFlow({ ...chart, ...newChart }));
   };
 
-  deleteSelection = () => {
-    this.state.actionCallbacks.onDeleteKey({});
+  const deleteSelection = () => {
+    actionCallbacks.onDeleteKey({});
   };
 
-  updateFlow = (flow: any, event: any) => {
-    if (syncEvents.includes(event)) return this.syncFlow(flow);
-    this.setState({ chart: flow });
-  };
-
-  syncFlow = (flow: Flow) => {
-    this.props.updateFlow(flow);
-  };
-  //todo can't find usages. Maybe we can delete that
-  selectNode = (data: any) => {
-    Dispatcher.dispatch({
-      actionType: Constants.SELECT_NODE,
-      payload: data.nodeId,
-    });
-  };
-
-  copyChartAsYAML = () => {
-    copyToClipboard(formatAsYAML(this.props.chart));
+  const copyChartAsYAML = () => {
+    copyToClipboard(formatAsYAML(chart));
     alert("Chart copied to clipboard as YAML");
   };
-
-  validateLink = ({ fromNodeId, toNodeId, fromPortId, toPortId }: any) => {
+  const validateLink = ({
+    fromNodeId,
+    toNodeId,
+    fromPortId,
+    toPortId,
+  }: any) => {
     return !(fromNodeId === toNodeId || fromPortId === toPortId);
   };
 
-  showImportModal = () => {
+  const showImportModal = () => {
     Dispatcher.dispatch({
       actionType: Constants.SHOW_MODAL,
       payload: { modal: "import" },
     });
   };
 
-  loadFlow = (flowId: string) => {
-    this.props.loadFlow(flowId);
-  };
-
-  createNewFlow = (e: any) => {
+  const handleCreateNewFlow = (e: any) => {
     e.preventDefault();
     e.stopPropagation();
 
-    this.props.createNewFlow();
+    dispatch(createNewFlow());
   };
 
-  deleteFlow = (e: any, flowId: any) => {
+  const handleDeleteFlow = (e: any, flowId: any) => {
     e.preventDefault();
     e.stopPropagation();
 
-    this.props.deleteFlow(flowId);
+    dispatch(deleteFlow(flowId));
   };
 
-  duplicateFlow = () => {
-    const yaml = formatAsYAML(this.props.chart);
-    this.props.duplicateFlow(yaml);
+  const handleDuplicateFlow = () => {
+    const yaml = formatAsYAML(chart);
+    dispatch(duplicateFlow(yaml));
   };
 
-  render = () => {
-    const {
-      showOverlay,
-      connected,
-      availableProperties,
-      actionCallbacks,
-    } = this.state;
+  const readonly = flowType !== "user-generated";
 
-    const { type: flowType } = this.props.flowChart;
-
-    const readonly = flowType !== "user-generated";
-    return (
-      <Container fluid className="main-content-container px-0">
-        <div className="px-4">
-          <a href="/#" id="download-link" style={{ display: "none" }}>
-            download
-          </a>
-          <Row noGutters className="page-header mb-4">
-            <PageTitle title="Flow Design" className="text-sm-left mb-3" />
-          </Row>
-          <div className="flow-container d-flex flex-column flex-md-row">
-            <Card className="chart-section-container mr-md-4 mb-4">
-              <FlowSelection
-                connected={connected}
-                flows={this.props.flows}
-                selectedFlowId={this.props.selectedFlowId}
-                createNewFlow={this.createNewFlow}
-                loadFlow={this.loadFlow}
-                deleteFlow={this.deleteFlow}
-              />
-              <CommandBar
-                copyChart={this.copyChartAsYAML}
-                importChart={this.showImportModal}
-                exportImage={this.exportImage}
-              />
-              <div className="chart-container">
-                <div
-                  className="capture-overlay"
-                  style={{ display: showOverlay ? "" : "none" }}
-                >
-                  <div className="capture-overlay-top"></div>
-                  <div className="capture-overlay-bottom"></div>
-                </div>
-                <FlowChart
-                  chart={this.props.chart}
-                  Components={{
-                    TooltipComponent: Tooltip,
-                    NodeInner: CustomNode as any,
-                    Port: CustomPort,
-                  }}
-                  callbacks={actionCallbacks}
-                  config={{
-                    readonly,
-                    validateLink: this.validateLink,
-                  }}
-                />
-              </div>
-            </Card>
-            <Sidebar
-              availableProperties={availableProperties}
-              duplicateFlow={this.duplicateFlow}
-              readonly={readonly}
-              flow={this.props.chart}
-              deleteSelection={this.deleteSelection}
-              updateNode={this.updateNode}
-              updateLink={this.updateLink}
+  return (
+    <Container fluid className="main-content-container px-0">
+      <div className="px-4">
+        <a href="/#" id="download-link" style={{ display: "none" }}>
+          download
+        </a>
+        <Row noGutters className="page-header mb-4">
+          <PageTitle title="Flow Design" className="text-sm-left mb-3" />
+        </Row>
+        <div className="flow-container d-flex flex-column flex-md-row">
+          <Card className="chart-section-container mr-md-4 mb-4">
+            <FlowSelection
+              connected={connected}
+              flows={flows}
+              selectedFlowId={selectedFlowId}
+              createNewFlow={handleCreateNewFlow}
+              loadFlow={(flowId) => dispatch(loadFlow(flowId))}
+              deleteFlow={handleDeleteFlow}
             />
-          </div>
+            <CommandBar
+              copyChart={copyChartAsYAML}
+              importChart={showImportModal}
+              exportImage={exportImage}
+            />
+            <div className="chart-container">
+              <div
+                className="capture-overlay"
+                style={{ display: showOverlay ? "" : "none" }}
+              >
+                <div className="capture-overlay-top"></div>
+                <div className="capture-overlay-bottom"></div>
+              </div>
+              <FlowChart
+                chart={(chart as unknown) as IChart}
+                Components={{
+                  TooltipComponent: Tooltip,
+                  NodeInner: CustomNode as any,
+                  Port: CustomPort,
+                }}
+                callbacks={actionCallbacks}
+                config={{
+                  readonly,
+                  validateLink: validateLink,
+                }}
+              />
+            </div>
+          </Card>
+          <Sidebar
+            availableProperties={availableProperties}
+            duplicateFlow={handleDuplicateFlow}
+            readonly={readonly}
+            flow={chart}
+            deleteSelection={deleteSelection}
+            updateNode={updateNode}
+            updateLink={updateLink}
+          />
         </div>
-      </Container>
-    );
-  };
+      </div>
+    </Container>
+  );
 }
-
-function mapStateToProps(state: State) {
-  const flowChart = selectFlowChart(state);
-  const { flow: chart } = flowChart;
-  const chartWithTooltips = {
-    ...chart,
-    ...tooltipConfig,
-  };
-  return {
-    chart: chartWithTooltips,
-    flowChart,
-    flows: selectFlows(state),
-    selectedFlowId: selectSelectedFlowId(state),
-  };
-}
-
-export default connect(mapStateToProps, {
-  loadFlow,
-  createNewFlow,
-  updateFlow,
-  duplicateFlow,
-  deleteFlow,
-})(FlowView);

--- a/src/views/FlowView.tsx
+++ b/src/views/FlowView.tsx
@@ -25,6 +25,7 @@ import CommandBar from "../components/FlowChart/CommandBar";
 import {
   FlowChart,
   IChart,
+  IOnLinkCompleteInput,
 } from "@bastinjafari/react-flow-chart-with-tooltips-and-multi-select";
 import Tooltip from "../components/FlowChart/Tooltip";
 import CustomNode from "../components/FlowChart/ChartNode";
@@ -154,7 +155,7 @@ export default function FlowView() {
     toNodeId,
     fromPortId,
     toPortId,
-  }: any) => {
+  }: IOnLinkCompleteInput) => {
     return !(fromNodeId === toNodeId || fromPortId === toPortId);
   };
 


### PR DESCRIPTION
Refactor Flowview class component to functional component.

I got rid of:

```
    if (syncEvents.includes(event)) return this.syncFlow(flow);
    this.setState({ chart: flow });
```

because we need a new way of triggering a rerender (this.setState does it in the class, dispatching an action does it in the function). And we need a rerender everytime something changes with the chart/flow, so checking for specific types of events didn't seem to make sense to me.
I also think that the check didn't make sense in the class, because a rerender was triggered anyway with calling this.setState