### PR TITLE
Fix: Hide taskView

### DIFF
--- a/src/redux/global/global.constants.ts
+++ b/src/redux/global/global.constants.ts
@@ -25,12 +25,6 @@ const navItems: TNavItem[] = [
     matches: ["logs"],
   },
   {
-    title: "Task",
-    to: "/task",
-    iconName: "assessment",
-    matches: ["task"],
-  },
-  {
     title: "Flow Design",
     to: "/flow",
     iconName: "device_hub",


### PR DESCRIPTION
Tasks are currently not implemented in JinaD. So we should hide the view for now.