### PR TITLE
fix(hub): don't display images when no images match the query

### DIFF
--- a/src/components/Hub/HubImagesList.tsx
+++ b/src/components/Hub/HubImagesList.tsx
@@ -4,6 +4,7 @@ import { Row, Col } from "react-bootstrap"
 import { fetchHubImages } from "../../redux/hub/hub.actions"
 import {
   selectHubImages,
+  selectHubImagesFetchError,
   selectIsHubImagesLoading,
 } from "../../redux/hub/hub.selectors"
 import { HubImage } from "../../redux/hub/hub.types"
@@ -36,6 +37,11 @@ const SearchContainer = styled(Row)`
   padding: 1rem;
 `
 
+const EmptyResultMessage = styled.h3`
+  margin-top: 25px;
+  text-align: center;
+`
+
 export const getImageFilters = (images: HubImage[], filters: Filter[]) => {
   return [
     {
@@ -66,9 +72,10 @@ const HubImagesList = () => {
   const dispatch = useDispatch()
   const hubImages = useSelector(selectHubImages)
   const isHubImagesLoading = useSelector(selectIsHubImagesLoading)
+  const hubImagesFetchError = useSelector(selectHubImagesFetchError)
   let [filters, setFilters] = useState([] as Filter[])
   let [searchString, setSearchString] = useState("")
-  if (hubImages.length === 0 && !isHubImagesLoading) {
+  if (hubImages.length === 0 && !isHubImagesLoading && !hubImagesFetchError) {
     dispatch(fetchHubImages())
   }
 
@@ -109,17 +116,23 @@ const HubImagesList = () => {
                 onSearch={onSearch}
               />
             </SearchContainer>
-            <Row data-name="hubImagesList">
-              {hubImages.map((image, index) => (
-                <Col
-                  key={`${image.name}.${image.version}.${image["jina-version"]}`}
-                  md="4"
-                  className="mb-4"
-                >
-                  <ImageCard image={image} index={index} />
-                </Col>
-              ))}
-            </Row>
+            {hubImages.length ? (
+              <Row data-name="hubImagesList">
+                {hubImages.map((image, index) => (
+                  <Col
+                    key={`${image.name}.${image.version}.${image["jina-version"]}`}
+                    md="4"
+                    className="mb-4"
+                  >
+                    <ImageCard image={image} index={index} />
+                  </Col>
+                ))}
+              </Row>
+            ) : (
+              <EmptyResultMessage>
+                No images matching your search were found
+              </EmptyResultMessage>
+            )}
           </Col>
         </Row>
       )}

--- a/src/redux/hub/hub.reducer.ts
+++ b/src/redux/hub/hub.reducer.ts
@@ -15,8 +15,10 @@ const hubReducer = produce((draft: HubState, action: HubActionTypes) => {
     case FETCH_HUB_IMAGES_SUCCESS:
       draft.loading = false
       draft.images = action.payload.images
+      draft.error = null
       break
     case FETCH_HUB_IMAGES_FAILURE:
+      draft.images = []
       draft.loading = false
       draft.error = action.payload.error
       break

--- a/src/redux/hub/hub.selectors.ts
+++ b/src/redux/hub/hub.selectors.ts
@@ -17,3 +17,6 @@ export const selectHubImages = (state: State) =>
 
 export const selectIsHubImagesLoading = (state: State) =>
   state.hubState.loading;
+
+export const selectHubImagesFetchError = (state: State) =>
+  state.hubState.error

--- a/src/redux/hub/hub.test.ts
+++ b/src/redux/hub/hub.test.ts
@@ -7,7 +7,7 @@ import {
 } from "./hub.constants";
 import { HubState, HubActionTypes, HubImage } from "./hub.types";
 import hubReducer from "./hub.reducer";
-import { selectHubImages, selectIsHubImagesLoading } from "./hub.selectors";
+import { selectHubImages, selectIsHubImagesLoading, selectHubImagesFetchError } from "./hub.selectors";
 import configureMockStore from "redux-mock-store";
 import thunk, { ThunkDispatch } from "redux-thunk";
 import { AnyAction } from "redux";
@@ -86,6 +86,26 @@ describe("hub reducer", () => {
       ).images
     ).toEqual(["Starry night", "Water lillies"]);
   });
+  it("sets state error to null if fetching images succeeds", () => {
+    expect(
+      hubReducer(
+        {
+          images: [],
+          loading: true,
+          error: { name: "error name", message: "error message" },
+        },
+        {
+          type: FETCH_HUB_IMAGES_SUCCESS,
+          payload: {
+            images: ([
+              "Starry night",
+              "Water lillies",
+            ] as unknown) as HubImage[],
+          },
+        }
+      ).error
+    ).toEqual(null);
+  });
   it("sets state to loading on fetching images", () => {
     expect(
       hubReducer(
@@ -116,6 +136,26 @@ describe("hub reducer", () => {
       ).error?.name
     ).toEqual("unfortunate error");
   });
+  it("sets state images to [] if fetching images fails", () => {
+    expect(
+      hubReducer(
+        {
+          images: (["Starry night", "Water lillies"] as unknown) as HubImage[],
+          loading: true,
+          error: null,
+        },
+        {
+          type: FETCH_HUB_IMAGES_FAILURE,
+          payload: {
+            error: {
+              name: "unfortunate error",
+              message: "it went south so quick",
+            },
+          },
+        }
+      ).images
+    ).toEqual([]);
+  })
 });
 
 describe("hub selectors", () => {
@@ -146,4 +186,19 @@ describe("hub selectors", () => {
       ).toEqual(expectedImages);
     });
   });
+
+  describe("selectHubImagesFetchError", () => {
+    it("returns hubState error property", () => {
+      const error = {
+        name: "error name",
+        message: "error message",
+      }
+      expect(selectHubImagesFetchError({ hubState: { error } } as State)).toBe(
+        error
+      )
+      expect(
+        selectHubImagesFetchError({ hubState: { error: null } } as State)
+      ).toBe(null)
+    })
+  })
 });


### PR DESCRIPTION
This PR solves #274 

The issue was that when no images match the search query, the images in redux store weren't removed, which results in the user seeing the previous search result.

The changes introduced by this PR make sure that the images stored in redux are set to an empty array whenever the search fails, and also displays a message saying "No images matching your search were found" to the user.

<img width="1342" alt="Screenshot 2021-03-27 at 15 49 28" src="https://user-images.githubusercontent.com/12495892/112724896-bc3afe00-8f15-11eb-8b62-10d39d832795.png">

<h2>PR checklist</h2>

**Docs**
- [x] If you added new code; is it self documenting? (all the variable names clear, comments added where appropriate)
- [ ] If you touched existing code; did you refactor existing naming, added comments where necessary?

**Tests**
- [x] If your ticket adds new functionality; have you added unit tests to verify behaviour?
- [ ] If your ticket alters user interaction with the UI; have you added integration tests?
- [ ] Do your tests check for every _convievable_ user behabviour? (all behaviours the user _can_ perform)

**Typing**
- [ ] If you added new code; have you added typing?
- [ ] If you touched existing code; have you improved its typing?

**Styling**
- [x] If new styles were created; Did you refactor/add more styles in css-in-js style?
