### PR TITLE
style(settings): add styles in settings menu form

### DIFF
--- a/src/components/Settings/FormItem.tsx
+++ b/src/components/Settings/FormItem.tsx
@@ -6,21 +6,25 @@ type Props = {
   label: string
   value: SettingName
   placeholder: string
-  onChange: (e: ChangeEvent<HTMLInputElement>) => void
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void
 }
 
 export default function FormItem({
-  colSpan = 6,
   label,
   value,
   placeholder,
   onChange,
 }: Props) {
   return (
-    <div className="form-group">
-      <label>{label}</label>
+    <div className="form-group flex flex-col">
+      <div className="text-gray-400 mb-2" id={label}>
+        {label}
+      </div>
       <input
-        data-name={label.replaceAll(" ", "")}
+        className="border rounded-md py-2 px-3 text-gray-500 text-sm"
+        aria-labelledby={label}
+        aria-label={label}
+        data-name={label.replace(/ /g, "")}
         placeholder={placeholder}
         value={value}
         onChange={onChange}

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -6,12 +6,11 @@ import { SettingName, SettingUpdate } from "../../redux/settings/settings.types"
 import { useDispatch, useSelector } from "react-redux"
 import { updateSettings } from "../../redux/settings/settings.actions"
 import { selectSettings } from "../../redux/settings/settings.selectors"
-import Button from "../Common/Button"
+import { ToggleButton } from "./ToggleButton"
 
-function SettingsCard() {
+const SettingsCard = () => {
   const [updates, setUpdates] = useState<SettingUpdate>({})
-  const [expanded, setExpanded] = useState(false)
-
+  const [isToggleButtonExpanded, setIsToggleButtonExpanded] = useState(false)
   const settings = useSelector(selectSettings)
 
   const dispatch = useDispatch()
@@ -26,72 +25,67 @@ function SettingsCard() {
     dispatch(updateSettings(updates))
   }
 
-  function toggleExpand() {
-    setExpanded(!expanded)
+  function handleToggleButtonClick() {
+    setIsToggleButtonExpanded(!isToggleButtonExpanded)
   }
 
+  const renderBaseOptions = baseOptions.map(({ label, placeholder, value }) => (
+    <FormItem
+      key={value as string}
+      label={label}
+      placeholder={placeholder}
+      value={
+        (value in updates ? updates[value] : settings[value]) as SettingName
+      }
+      onChange={(e) => changeSetting(value, e.target.value)}
+    />
+  ))
+
+  const renderAdvancedOptions = advancedOptions.map(
+    ({ label, placeholder, value }) => (
+      <FormItem
+        key={value}
+        label={label}
+        placeholder={placeholder}
+        value={
+          (value in updates ? updates[value] : settings[value]) as SettingName
+        }
+        onChange={(e) => changeSetting(value as SettingName, e.target.value)}
+      />
+    )
+  )
+
   return (
-    <div className="mb-4">
-      <div className="border-bottom">
-        <h6 className="m-0">Connection Preferences</h6>
-      </div>
-      <div>
-        <div>
-          <div>
-            {baseOptions.map(({ label, placeholder, value }) => (
-              <FormItem
-                key={value as string}
-                label={label}
-                placeholder={placeholder}
-                value={
-                  (value in updates
-                    ? updates[value]
-                    : settings[value]) as SettingName
-                }
-                onChange={(e) => changeSetting(value, e.target.value)}
-              />
-            ))}
-          </div>
-          <div>
-            <div>
-              <strong
-                aria-controls="collapsed-form"
-                aria-expanded={expanded}
-                onClick={toggleExpand}
-                className="text-primary d-inline-block mb-3 cursor-pointer"
-              >
-                Advanced{" "}
-                <i className="material-icons">
-                  {expanded ? "arrow_drop_up" : "arrow_drop_down"}
-                </i>
+    <div className=" bg-white  rounded-md">
+      <h6 className="p-4 border-b text-gray-600">Connection Preferences</h6>
+      <div className="p-4">
+        <div className="grid grid-cols-2 gap-4 mb-4">{renderBaseOptions}</div>
+        <div className="flex mb-4 justify-between items-center">
+          <ToggleButton
+            isExpanded={isToggleButtonExpanded}
+            onToggleButtonClick={handleToggleButtonClick}
+          />
+          <button
+            className="bg-primary text-white text-xs py-2 px-4 rounded hover:shadow-lg active:shadow-inner"
+            onClick={saveChanges}
+          >
+            Save Changes
+          </button>
+        </div>
+        <div
+          style={{ height: isToggleButtonExpanded ? "290px" : "0px" }}
+          className={`pb-2 relative transition transition-height overflow-hidden duration-300 ease-in-out`}
+        >
+          {isToggleButtonExpanded && (
+            <>
+              <strong className="font-medium inline-block text-gray-400  mb-3">
+                Endpoints
               </strong>
-            </div>
-            <div className="text-right">
-              <Button onClick={saveChanges}>Save Changes</Button>
-            </div>
-          </div>
-          <div>
-            <div id="collapsed-form">
-              <strong className="text-muted d-block mb-3">Endpoints</strong>
-              <div>
-                {advancedOptions.map(({ label, placeholder, value }) => (
-                  <FormItem
-                    key={value}
-                    label={label}
-                    placeholder={placeholder}
-                    value={
-                      (value in updates
-                        ? updates[value]
-                        : settings[value]) as SettingName
-                    }
-                    onChange={(e) =>
-                      changeSetting(value as SettingName, e.target.value)
-                    }
-                  />
-                ))}
+              <div className="grid grid-cols-2 gap-4">
+                {renderAdvancedOptions}
               </div>
-            </div>
-          </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -10,7 +10,7 @@ import { ToggleButton } from "./ToggleButton"
 
 const SettingsCard = () => {
   const [updates, setUpdates] = useState<SettingUpdate>({})
-  const [isToggleButtonExpanded, setIsToggleButtonExpanded] = useState(false)
+  const [expanded, setExpanded] = useState(false)
   const settings = useSelector(selectSettings)
 
   const dispatch = useDispatch()
@@ -25,8 +25,8 @@ const SettingsCard = () => {
     dispatch(updateSettings(updates))
   }
 
-  function handleToggleButtonClick() {
-    setIsToggleButtonExpanded(!isToggleButtonExpanded)
+  function toggleExpand() {
+    setExpanded(!expanded)
   }
 
   const renderBaseOptions = baseOptions.map(({ label, placeholder, value }) => (
@@ -61,10 +61,7 @@ const SettingsCard = () => {
       <div className="p-4">
         <div className="grid grid-cols-2 gap-4 mb-4">{renderBaseOptions}</div>
         <div className="flex mb-4 justify-between items-center">
-          <ToggleButton
-            isExpanded={isToggleButtonExpanded}
-            onToggleButtonClick={handleToggleButtonClick}
-          />
+          <ToggleButton isExpanded={expanded} onClick={toggleExpand} />
           <button
             className="bg-primary text-white text-xs py-2 px-4 rounded hover:shadow-lg active:shadow-inner"
             onClick={saveChanges}
@@ -73,10 +70,10 @@ const SettingsCard = () => {
           </button>
         </div>
         <div
-          style={{ height: isToggleButtonExpanded ? "290px" : "0px" }}
+          style={{ height: expanded ? "290px" : "0px" }}
           className={`pb-2 relative transition transition-height overflow-hidden duration-300 ease-in-out`}
         >
-          {isToggleButtonExpanded && (
+          {expanded && (
             <>
               <strong className="font-medium inline-block text-gray-400  mb-3">
                 Endpoints

--- a/src/components/Settings/ToggleButton.tsx
+++ b/src/components/Settings/ToggleButton.tsx
@@ -1,0 +1,26 @@
+import React from "react"
+
+type ToggleButtonProps = {
+  isExpanded: boolean
+  onToggleButtonClick: () => void
+}
+
+export const ToggleButton = ({
+  isExpanded,
+  onToggleButtonClick,
+}: ToggleButtonProps) => {
+  return (
+    <button className="bg-transparent" onClick={onToggleButtonClick}>
+      <strong
+        aria-controls="collapsed-form"
+        aria-expanded={isExpanded}
+        className="text-primary font-medium d-inline-block"
+      >
+        Advanced{" "}
+        <i className="material-icons align-middle">
+          {isExpanded ? "arrow_drop_up" : "arrow_drop_down"}
+        </i>
+      </strong>
+    </button>
+  )
+}

--- a/src/components/Settings/ToggleButton.tsx
+++ b/src/components/Settings/ToggleButton.tsx
@@ -2,15 +2,12 @@ import React from "react"
 
 type ToggleButtonProps = {
   isExpanded: boolean
-  onToggleButtonClick: () => void
+  onClick: () => void
 }
 
-export const ToggleButton = ({
-  isExpanded,
-  onToggleButtonClick,
-}: ToggleButtonProps) => {
+export const ToggleButton = ({ isExpanded, onClick }: ToggleButtonProps) => {
   return (
-    <button className="bg-transparent" onClick={onToggleButtonClick}>
+    <button className="bg-transparent" onClick={onClick}>
       <strong
         aria-controls="collapsed-form"
         aria-expanded={isExpanded}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,21 @@
+const colors = require("tailwindcss/colors")
+
 module.exports = {
-  purge: ['./src/**/*.{js,jsx,ts,tsx}', './public/index.html'],
+  purge: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
   darkMode: false, // or 'media' or 'class'
   theme: {
-    extend: {},
+    transitionProperty: {
+      height: "height",
+    },
+    colors: {
+      ...colors,
+      primary: "#009999",
+    },
   },
   variants: {
-    extend: {},
+    extend: {
+      boxShadow: ["active"],
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Why are the changes necessary?

- To fix issue - This PR closes issue #360 

## What does this pull request cover?

- Add styles to form in settings menu, used tailwind classes to style the component.
- Tailwind has been added with the following configs
   1. 'height' property is added to transitionProperty
   2. 'boxShadow' property is added to the 'active' pseudo class.
   3. 'primary'  property for color  has been added to access application's primary color from tailwind classes.

## Demo

![jina-settings](https://user-images.githubusercontent.com/4848556/132102514-865dc5eb-278c-423c-8457-283d0e270dd6.gif)

